### PR TITLE
Update to Sencha CMD 6.2.2.36

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,15 +11,15 @@ RUN \
 
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
-ENTRYPOINT ["/opt/Sencha/Cmd/6.1.1.76/sencha"]
+ENTRYPOINT ["/opt/Sencha/Cmd/6.2.2.36/sencha"]
 
 ADD sencha-compass.zip /
 
-RUN curl -o /cmd.run.zip http://cdn.sencha.com/cmd/6.1.1.76/SenchaCmd-6.1.1.76-linux-amd64.sh.zip && \
+RUN curl -o /cmd.run.zip http://cdn.sencha.com/cmd/6.2.2.36/SenchaCmd-6.2.2.36-linux-amd64.sh.zip && \
     unzip -p /cmd.run.zip > /cmd-install.run && \
     chmod +x /cmd-install.run && \
-    /cmd-install.run -q -dir /opt/Sencha/Cmd/6.1.1.76 && \
+    /cmd-install.run -q -dir /opt/Sencha/Cmd/6.2.2.36 -Dall=true && \
     install -dm777 -o root -g root /opt/Sencha/Cmd/repo && \
     unzip /sencha-compass.zip && rm /sencha-compass.zip && \
-    mv /sencha-compass /opt/Sencha/Cmd/6.1.1.76/extensions/sencha-compass && \
+    mv /sencha-compass /opt/Sencha/Cmd/6.2.2.36/extensions/sencha-compass && \
     rm /cmd-install.run /cmd.run.zip

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 sencha-cmd docker
 =================
 
-Docker image to run Sencha Cmd 6.1.1.76 with Sencha Compass
+Docker image to run Sencha Cmd 6.2.2.36 with Sencha Compass
 
 Build Production App
 --------------------


### PR DESCRIPTION
Mostly straightforward. For thermeon/rentl#23

We keep sencha compass in case someone uses the image to build Ext5 apps.

We could be more formal about docker image tags, any ideas?